### PR TITLE
chg: default bttc RPC to listen localhost only

### DIFF
--- a/mainnet-v1/sentry/validator/bttc/start.sh
+++ b/mainnet-v1/sentry/validator/bttc/start.sh
@@ -12,7 +12,7 @@ ADDRESS="`cat $BTTC_DIR/address.txt`"
 bttc --datadir $DATA_DIR \
   --port 30303 \
   --bor.heimdall "http://localhost:1317" \
-  --http --http.addr '0.0.0.0' \
+  --http --http.addr '127.0.0.1' \
   --http.vhosts '*' \
   --http.corsdomain '*' \
   --http.port 8545 \

--- a/mainnet-v1/without-sentry/bttc/start.sh
+++ b/mainnet-v1/without-sentry/bttc/start.sh
@@ -12,7 +12,7 @@ ADDRESS="`cat $BTTC_DIR/address.txt`"
 bttc --datadir $DATA_DIR \
   --port 30303 \
   --bor.heimdall "http://localhost:1317" \
-  --http --http.addr '0.0.0.0' \
+  --http --http.addr '127.0.0.1' \
   --http.vhosts '*' \
   --http.corsdomain '*' \
   --http.port 8545 \

--- a/testnet-1029/sentry/validator/bttc/start.sh
+++ b/testnet-1029/sentry/validator/bttc/start.sh
@@ -11,7 +11,7 @@ ADDRESS="`cat $BTTC_DIR/address.txt`"
 bttc --datadir $DATA_DIR \
   --port 30303 \
   --bor.heimdall "http://localhost:1317" \
-  --http --http.addr '0.0.0.0' \
+  --http --http.addr '127.0.0.1' \
   --http.vhosts '*' \
   --http.corsdomain '*' \
   --http.port 8545 \

--- a/testnet-1029/without-sentry/bttc/start.sh
+++ b/testnet-1029/without-sentry/bttc/start.sh
@@ -16,7 +16,7 @@ DATA_DIR=$BTTC_DIR/data
 bttc --datadir $DATA_DIR \
   --port 30303 \
   --bor.heimdall "http://localhost:1317" \
-  --http --http.addr '0.0.0.0' \
+  --http --http.addr '127.0.0.1' \
   --http.vhosts '*' \
   --http.corsdomain '*' \
   --http.port 8545 \


### PR DESCRIPTION
change start.sh param to set default bor rpc from '0.0.0.0' to '127.0.0.1' to listen localhost only.