### PR TITLE
Add --home option for delivery setup script

### DIFF
--- a/mainnet-v1/sentry/sentry/delivery/setup.sh
+++ b/mainnet-v1/sentry/sentry/delivery/setup.sh
@@ -4,7 +4,7 @@ NODE_DIR=~/node
 DELIVERY_HOME=~/.deliveryd
 
 # init delivery node
-deliveryd init --chain-id delivery-199
+deliveryd init --home $DELIVERY_HOME_DIR --chain-id delivery-199
 
 # copy node directories to home directories
 cp -rf $NODE_DIR/delivery/config/genesis.json $DELIVERY_HOME/config/

--- a/mainnet-v1/sentry/sentry/delivery/setup.sh
+++ b/mainnet-v1/sentry/sentry/delivery/setup.sh
@@ -4,7 +4,7 @@ NODE_DIR=~/node
 DELIVERY_HOME=~/.deliveryd
 
 # init delivery node
-deliveryd init --home $DELIVERY_HOME_DIR --chain-id delivery-199
+deliveryd init --home $DELIVERY_HOME --chain-id delivery-199
 
 # copy node directories to home directories
 cp -rf $NODE_DIR/delivery/config/genesis.json $DELIVERY_HOME/config/


### PR DESCRIPTION
Add --home option to delivery/setup.sh so it can generate config files to the appropriate path if someone wants to use a different data directory.